### PR TITLE
Set admin rolle før flyway migrering starter

### DIFF
--- a/src/main/java/no/nav/veilarboppgave/config/DatabaseMigrationConfig.java
+++ b/src/main/java/no/nav/veilarboppgave/config/DatabaseMigrationConfig.java
@@ -2,11 +2,14 @@ package no.nav.veilarboppgave.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.common.utils.EnvironmentUtils;
 import org.flywaydb.core.Flyway;
 import org.springframework.context.annotation.Configuration;
 
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
+
+import static java.lang.String.format;
 
 
 @Slf4j
@@ -20,8 +23,11 @@ public class DatabaseMigrationConfig {
     public void migrateDb() {
         log.info("Starting database migration...");
 
+        String environment = EnvironmentUtils.isDevelopment().orElse(true) ? "dev" : "prod";
+
         Flyway.configure()
                 .dataSource(dataSource)
+                .initSql(format("SET ROLE \"veilarboppgave-%s-admin\"", environment))
                 .load()
                 .migrate();
     }


### PR DESCRIPTION
Hvis ikke admin rollen blir satt så vil det skape problemer i etterkant hvis andre migreringer prøver å gjøre endringer på samme ting