### PR TITLE
Ikke bruke fnr i path og query params

### DIFF
--- a/src/main/java/no/nav/veilarboppgave/controller/v1/EnheterController.java
+++ b/src/main/java/no/nav/veilarboppgave/controller/v1/EnheterController.java
@@ -1,4 +1,4 @@
-package no.nav.veilarboppgave.controller;
+package no.nav.veilarboppgave.controller.v1;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.AktorId;

--- a/src/main/java/no/nav/veilarboppgave/controller/v1/InternalController.java
+++ b/src/main/java/no/nav/veilarboppgave/controller/v1/InternalController.java
@@ -1,4 +1,4 @@
-package no.nav.veilarboppgave.controller;
+package no.nav.veilarboppgave.controller.v1;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.common.health.selftest.SelfTestChecks;

--- a/src/main/java/no/nav/veilarboppgave/controller/v1/OppgaveController.java
+++ b/src/main/java/no/nav/veilarboppgave/controller/v1/OppgaveController.java
@@ -1,4 +1,4 @@
-package no.nav.veilarboppgave.controller;
+package no.nav.veilarboppgave.controller.v1;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.AktorId;

--- a/src/main/java/no/nav/veilarboppgave/controller/v1/OppgavehistorikkController.java
+++ b/src/main/java/no/nav/veilarboppgave/controller/v1/OppgavehistorikkController.java
@@ -1,4 +1,4 @@
-package no.nav.veilarboppgave.controller;
+package no.nav.veilarboppgave.controller.v1;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.AktorId;

--- a/src/main/java/no/nav/veilarboppgave/controller/v2/EnheterControllerV2.java
+++ b/src/main/java/no/nav/veilarboppgave/controller/v2/EnheterControllerV2.java
@@ -1,0 +1,37 @@
+package no.nav.veilarboppgave.controller.v2;
+
+import lombok.RequiredArgsConstructor;
+import no.nav.common.types.identer.AktorId;
+import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppgave.domain.EnheterRequest;
+import no.nav.veilarboppgave.domain.OppfolgingEnhet;
+import no.nav.veilarboppgave.service.AuthService;
+import no.nav.veilarboppgave.service.EnheterService;
+import no.nav.veilarboppgave.util.Valider;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static no.nav.veilarboppgave.util.OppgaveUtils.tilTemaDto;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/enheter")
+public class EnheterControllerV2 {
+
+    private final EnheterService enheterService;
+    private final AuthService authService;
+
+    @PostMapping
+    public List<OppfolgingEnhet> hentEnheter(@RequestBody EnheterRequest enheterRequest, @RequestParam("tema") String tema) {
+        Fnr fnr = enheterRequest.fnr();
+        AktorId aktorid = authService.getAktorIdOrThrow(fnr);
+
+        authService.sjekkLesetilgangMedAktorId(aktorid);
+
+        Valider.validerTema(tema);
+
+        return enheterService.hentEnheter(fnr, tilTemaDto(tema));
+    }
+
+}

--- a/src/main/java/no/nav/veilarboppgave/controller/v2/OppgavehistorikkControllerV2.java
+++ b/src/main/java/no/nav/veilarboppgave/controller/v2/OppgavehistorikkControllerV2.java
@@ -1,0 +1,32 @@
+package no.nav.veilarboppgave.controller.v2;
+
+import lombok.RequiredArgsConstructor;
+import no.nav.common.types.identer.AktorId;
+import no.nav.veilarboppgave.domain.Oppgavehistorikk;
+import no.nav.veilarboppgave.domain.OppgavehistorikkRequest;
+import no.nav.veilarboppgave.service.AuthService;
+import no.nav.veilarboppgave.service.OppgavehistorikkService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/oppgavehistorikk")
+public class OppgavehistorikkControllerV2 {
+
+    private final AuthService authService;
+    private final OppgavehistorikkService oppgavehistorikkService;
+
+    @PostMapping
+    public List<Oppgavehistorikk> getOppgavehistorikk(@RequestBody OppgavehistorikkRequest oppgavehistorikkRequest) {
+        AktorId aktorId = authService.getAktorIdOrThrow(oppgavehistorikkRequest.fnr());
+
+        authService.sjekkLesetilgangMedAktorId(aktorId);
+
+        return oppgavehistorikkService.hentOppgavehistorikk(aktorId);
+    }
+}

--- a/src/main/java/no/nav/veilarboppgave/domain/EnheterRequest.java
+++ b/src/main/java/no/nav/veilarboppgave/domain/EnheterRequest.java
@@ -1,0 +1,8 @@
+package no.nav.veilarboppgave.domain;
+
+import no.nav.common.types.identer.Fnr;
+
+public record EnheterRequest(
+        Fnr fnr
+) {
+}

--- a/src/main/java/no/nav/veilarboppgave/domain/OppgavehistorikkRequest.java
+++ b/src/main/java/no/nav/veilarboppgave/domain/OppgavehistorikkRequest.java
@@ -1,0 +1,8 @@
+package no.nav.veilarboppgave.domain;
+
+import no.nav.common.types.identer.Fnr;
+
+public record OppgavehistorikkRequest(
+        Fnr fnr
+) {
+}

--- a/src/test/java/no/nav/veilarboppgave/controller/v1/EnhetControllerTest.java
+++ b/src/test/java/no/nav/veilarboppgave/controller/v1/EnhetControllerTest.java
@@ -1,6 +1,7 @@
-package no.nav.veilarboppgave.controller;
+package no.nav.veilarboppgave.controller.v1;
 
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppgave.controller.v1.EnheterController;
 import no.nav.veilarboppgave.domain.TemaDTO;
 import no.nav.veilarboppgave.service.AuthService;
 import no.nav.veilarboppgave.service.EnheterService;

--- a/src/test/java/no/nav/veilarboppgave/controller/v1/OppgaveControllerTest.java
+++ b/src/test/java/no/nav/veilarboppgave/controller/v1/OppgaveControllerTest.java
@@ -1,5 +1,6 @@
-package no.nav.veilarboppgave.controller;
+package no.nav.veilarboppgave.controller.v1;
 
+import no.nav.veilarboppgave.controller.v1.OppgaveController;
 import no.nav.veilarboppgave.domain.OppgaveDTO;
 import no.nav.veilarboppgave.service.AuthService;
 import no.nav.veilarboppgave.service.OppgaveService;

--- a/src/test/java/no/nav/veilarboppgave/controller/v1/OppgavehistorikkControllerTest.java
+++ b/src/test/java/no/nav/veilarboppgave/controller/v1/OppgavehistorikkControllerTest.java
@@ -1,8 +1,9 @@
-package no.nav.veilarboppgave.controller;
+package no.nav.veilarboppgave.controller.v1;
 
 
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppgave.controller.v1.OppgavehistorikkController;
 import no.nav.veilarboppgave.domain.Oppgavehistorikk;
 import no.nav.veilarboppgave.domain.OppgavehistorikkDTO;
 import no.nav.veilarboppgave.repositoyry.OppgavehistorikkRepository;

--- a/src/test/java/no/nav/veilarboppgave/controller/v2/EnhetControllerV2Test.java
+++ b/src/test/java/no/nav/veilarboppgave/controller/v2/EnhetControllerV2Test.java
@@ -1,0 +1,42 @@
+package no.nav.veilarboppgave.controller.v2;
+
+import no.nav.veilarboppgave.domain.EnheterRequest;
+import no.nav.veilarboppgave.domain.TemaDTO;
+import no.nav.veilarboppgave.service.AuthService;
+import no.nav.veilarboppgave.service.EnheterService;
+import no.nav.veilarboppgave.utils.TestData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class EnhetControllerV2Test {
+
+    private EnheterControllerV2 enheterControllerV2;
+    private AuthService authServiceMock;
+
+    @BeforeEach
+    public void setUp() {
+        authServiceMock = mock(AuthService.class);
+        enheterControllerV2 = new EnheterControllerV2(mock(EnheterService.class), authServiceMock);
+    }
+
+    @Test
+    public void skal_sjekke_tilgang() {
+        EnheterRequest enheterRequest = new EnheterRequest(TestData.genererTilfeldigFnrUtenTilgang());
+
+        enheterControllerV2.hentEnheter(enheterRequest, TemaDTO.OPPFOLGING.name());
+
+        verify(authServiceMock, atLeastOnce()).sjekkLesetilgangMedAktorId(any());
+    }
+
+    @Test
+    public void skal_kaste_exception_ved_validering_av_ugyldig_tema() {
+        assertThrows(ResponseStatusException.class, () -> {
+            EnheterRequest enheterRequest = new EnheterRequest(TestData.genererTilfeldigFnrMedTilgang());
+            enheterControllerV2.hentEnheter(enheterRequest, "UGYLDIG_TEMA");
+        });
+    }
+}

--- a/src/test/java/no/nav/veilarboppgave/controller/v2/OppgavehistorikkControllerV2Test.java
+++ b/src/test/java/no/nav/veilarboppgave/controller/v2/OppgavehistorikkControllerV2Test.java
@@ -1,0 +1,64 @@
+package no.nav.veilarboppgave.controller.v2;
+
+
+import no.nav.common.types.identer.AktorId;
+import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppgave.domain.Oppgavehistorikk;
+import no.nav.veilarboppgave.domain.OppgavehistorikkDTO;
+import no.nav.veilarboppgave.domain.OppgavehistorikkRequest;
+import no.nav.veilarboppgave.repositoyry.OppgavehistorikkRepository;
+import no.nav.veilarboppgave.service.AuthService;
+import no.nav.veilarboppgave.service.OppgavehistorikkService;
+import no.nav.veilarboppgave.utils.SingletonPostgresContainer;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class OppgavehistorikkControllerV2Test {
+
+    private AuthService authService = mock(AuthService.class);
+
+    private OppgavehistorikkRepository oppgavehistorikkRepository;
+
+    private OppgavehistorikkControllerV2 oppgavehistorikkControllerV2;
+
+    @Before
+    public void resetMocks() {
+        JdbcTemplate db = SingletonPostgresContainer.init().createJdbcTemplate();
+        oppgavehistorikkRepository = new OppgavehistorikkRepository(db);
+        OppgavehistorikkService oppgavehistorikkService = new OppgavehistorikkService(oppgavehistorikkRepository);
+        oppgavehistorikkControllerV2 = new OppgavehistorikkControllerV2(authService, oppgavehistorikkService);
+
+        reset(authService);
+    }
+
+    @Test
+    public void skalHenteOppgavehistorikk() {
+        AktorId aktoerid = AktorId.of("4444");
+        OppgavehistorikkRequest oppgavehistorikkRequest = new OppgavehistorikkRequest(Fnr.of("3333"));
+
+        when(authService.getAktorIdOrThrow(any())).thenReturn(aktoerid);
+
+        oppgavehistorikkRepository.insertOppgaveHistorikk(getOppgaveHitorikk(aktoerid));
+        oppgavehistorikkRepository.insertOppgaveHistorikk(getOppgaveHitorikk(aktoerid));
+
+        List<Oppgavehistorikk> oppgavehistorikkDTOS = oppgavehistorikkControllerV2.getOppgavehistorikk(oppgavehistorikkRequest);
+        assertEquals(2, oppgavehistorikkDTOS.size());
+    }
+
+    private OppgavehistorikkDTO getOppgaveHitorikk(AktorId aktorId) {
+        return new OppgavehistorikkDTO("tema",
+                "type",
+                new Timestamp(0),
+                "X000000",
+                "GSAKID",
+                aktorId.get());
+    }
+
+}


### PR DESCRIPTION
Dette er en del av arbeidet med å migrere bort fra bruk av fnr i query-/path-params.
Oppretter nye endepunkter (under `/v2/`) der fnr er lagt i request-body. 