### PR TITLE
Legg på "/hent"-prefix på endepunkter som ble endre fra GET til POST

### DIFF
--- a/src/main/java/no/nav/veilarboppgave/controller/v2/EnheterControllerV2.java
+++ b/src/main/java/no/nav/veilarboppgave/controller/v2/EnheterControllerV2.java
@@ -1,5 +1,6 @@
 package no.nav.veilarboppgave.controller.v2;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
@@ -16,13 +17,14 @@ import static no.nav.veilarboppgave.util.OppgaveUtils.tilTemaDto;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v2/enheter")
+@RequestMapping("/api/v2")
 public class EnheterControllerV2 {
 
     private final EnheterService enheterService;
     private final AuthService authService;
 
-    @PostMapping
+    @PostMapping("/hent-enheter")
+    @Operation(summary = "Hent enheter")
     public List<OppfolgingEnhet> hentEnheter(@RequestBody EnheterRequest enheterRequest, @RequestParam("tema") String tema) {
         Fnr fnr = enheterRequest.fnr();
         AktorId aktorid = authService.getAktorIdOrThrow(fnr);

--- a/src/main/java/no/nav/veilarboppgave/controller/v2/OppgavehistorikkControllerV2.java
+++ b/src/main/java/no/nav/veilarboppgave/controller/v2/OppgavehistorikkControllerV2.java
@@ -1,5 +1,6 @@
 package no.nav.veilarboppgave.controller.v2;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.AktorId;
 import no.nav.veilarboppgave.domain.Oppgavehistorikk;
@@ -15,13 +16,14 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v2/oppgavehistorikk")
+@RequestMapping("/api/v2")
 public class OppgavehistorikkControllerV2 {
 
     private final AuthService authService;
     private final OppgavehistorikkService oppgavehistorikkService;
 
-    @PostMapping
+    @PostMapping("/hent-oppgavehistorikk")
+    @Operation(summary = "Hent oppgavehistorikk")
     public List<Oppgavehistorikk> getOppgavehistorikk(@RequestBody OppgavehistorikkRequest oppgavehistorikkRequest) {
         AktorId aktorId = authService.getAktorIdOrThrow(oppgavehistorikkRequest.fnr());
 


### PR DESCRIPTION
For å unngå potensiell kollisjon for opprettelse/henting av en ressurs, så har vi valgt å gå for å bruke "hent"-prefix for endepunkter som benytter `POST`-operasjonen men som brukes til henting.